### PR TITLE
Update main

### DIFF
--- a/main
+++ b/main
@@ -3,20 +3,7 @@
 #PBS -N biasfielcorr
 #PBS -V
 
-cd $PBS_O_WORKDIR
 module load ants
-
 rm -f t1.nii.gz
-rm -f finished
 
 N4BiasFieldCorrection -d 3 -i $(jq -r .t1 config.json) -o t1.nii.gz -s 4 -b [200] -c [50x50x50x50, 0.000001]
-
-
-if [ -s t1.nii.gz ]
-then 
-     echo 0 > finished
-else
-	echo "Bias Correction Failed"
-	echo 1 > finished
-	exit 1
-fi


### PR DESCRIPTION
cd to $PBS_O_WORKDIR is not necessar when it's run through the default hook as it sets `-d $PWD` when it tries to qsub. Also, it will cause workdir to reset to $HOME if $PBS_O_WORKDIR is not set (like on slurm). So I've removed it.

Instead of looking for t1.nii.gz, the return code from N4BiasFieldCorrection should be checked to see if the application finished successfully. Since bash passes the return code of the last command to parent script, so as long as N4BiasFieldCorrection is the last command on this script, you don't have to check it manually. Also, you don't have to write "finished" as it is already taken care of by the default hook.